### PR TITLE
[NO-JIRA] Fix warning in colored-output.gradle.kts

### DIFF
--- a/gradle/colored-output.gradle.kts
+++ b/gradle/colored-output.gradle.kts
@@ -59,6 +59,10 @@ tasks.withType<Test> {
                 }
 
                 when (result.resultType) {
+                    null -> {
+                        summaryStyle = ANSI_WHITE
+                    }
+
                     TestResult.ResultType.SUCCESS -> {
                         summaryStyle = ANSI_GREEN
                     }


### PR DESCRIPTION
JIRA issue: Aucun

##### PR summary:

- Corrige un warning dans `colored-output.gradle.kts`

##### Checklist for Developer:

- [x] Summary part has been documented
- [ ] Reviewers have been requested
- [ ] Reviews & comments have been taken into consideration
- [ ] Commits have been reworded and history cleaned

##### Checklist for Reviewer

- [ ] Code has been reviewed, commented and changes have been requested
- [ ] Reviews & comments have been taken into consideration


 
