### PR TITLE
[ZEE-6154] Add id to input and output ports

### DIFF
--- a/src/main/java/zeenea/connector/dataproduct/InputPort.java
+++ b/src/main/java/zeenea/connector/dataproduct/InputPort.java
@@ -9,6 +9,10 @@ import zeenea.connector.exception.ExceptionUtils;
 
 /** Represents an input port in a data product. */
 public final class InputPort {
+
+  /** The identifier of the input port. */
+  @NotNull private final ItemIdentifier id;
+
   /** The name of the input port. */
   @NotNull private final String name;
 
@@ -27,12 +31,23 @@ public final class InputPort {
    * @param builder the builder used to create the InputPort instance
    */
   private InputPort(Builder builder) {
+    Objects.requireNonNull(builder.id, "id");
     ExceptionUtils.requireNonNull("input", builder.inputs);
     ExceptionUtils.requireNonNull("output", builder.outputs);
+    this.id = builder.id;
     this.name = builder.name;
     this.description = builder.description;
     this.inputs = List.copyOf(builder.inputs);
     this.outputs = List.copyOf(builder.outputs);
+  }
+
+  /**
+   * Gets the identifier of the input port.
+   *
+   * @return the identifier of the input port
+   */
+  public @NotNull ItemIdentifier getId() {
+    return id;
   }
 
   /**
@@ -83,7 +98,8 @@ public final class InputPort {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     InputPort inputPort = (InputPort) o;
-    return Objects.equals(name, inputPort.name)
+    return Objects.equals(id, inputPort.id)
+        && Objects.equals(name, inputPort.name)
         && Objects.equals(description, inputPort.description)
         && Objects.equals(inputs, inputPort.inputs)
         && Objects.equals(outputs, inputPort.outputs);
@@ -96,7 +112,7 @@ public final class InputPort {
    */
   @Override
   public int hashCode() {
-    return Objects.hash(name, description, inputs, outputs);
+    return Objects.hash(id, name, description, inputs, outputs);
   }
 
   /**
@@ -107,9 +123,11 @@ public final class InputPort {
   @Override
   public String toString() {
     return "InputPort{"
-        + "description='"
+        + "id='"
+        + id
+        + "', description='"
         + description
-        + ", name='"
+        + "', name='"
         + name
         + "', inputs="
         + inputs
@@ -130,6 +148,8 @@ public final class InputPort {
   /** Builder class for creating instances of InputPort. */
   public static class Builder {
 
+    private ItemIdentifier id;
+
     private String name;
 
     private String description = null;
@@ -137,6 +157,17 @@ public final class InputPort {
     private List<ItemReference> inputs = Collections.emptyList();
 
     private List<ItemIdentifier> outputs = Collections.emptyList();
+
+    /**
+     * Sets the identifier of the input port.
+     *
+     * @param id the identifier of the input port
+     * @return the builder instance
+     */
+    public Builder id(@NotNull ItemIdentifier id) {
+      this.id = id;
+      return this;
+    }
 
     /**
      * Sets the name of the input port.

--- a/src/main/java/zeenea/connector/dataproduct/OutputPort.java
+++ b/src/main/java/zeenea/connector/dataproduct/OutputPort.java
@@ -3,12 +3,16 @@ package zeenea.connector.dataproduct;
 import java.util.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import zeenea.connector.common.ItemIdentifier;
 import zeenea.connector.dataset.Dataset;
 import zeenea.connector.exception.ExceptionUtils;
 import zeenea.connector.property.*;
 
 /** Represents an output port in a data product. */
 public final class OutputPort {
+
+  /** The identifier of the output port. */
+  @NotNull private final ItemIdentifier id;
 
   /** The name of the output port. */
   @NotNull private final String name;
@@ -31,15 +35,26 @@ public final class OutputPort {
    * @param builder the builder used to create the OutputPort instance
    */
   private OutputPort(Builder builder) {
+    Objects.requireNonNull(builder.id, "id");
     ExceptionUtils.requireNonNullOrEmpty("name", builder.name);
     Objects.requireNonNull(builder.dataContract, "dataContract");
     ExceptionUtils.requireNonNull("dataset", builder.datasets);
     ExceptionUtils.requireNonNull("properties", builder.properties);
+    this.id = builder.id;
     this.name = builder.name;
     this.description = builder.description;
     this.dataContract = builder.dataContract;
     this.datasets = builder.datasets;
     this.properties = builder.properties;
+  }
+
+  /**
+   * Gets the identifier of the output port.
+   *
+   * @return the identifier of the output port
+   */
+  public @NotNull ItemIdentifier getId() {
+    return id;
   }
 
   /**
@@ -99,7 +114,8 @@ public final class OutputPort {
     if (this == o) return true;
     if (!(o instanceof OutputPort)) return false;
     OutputPort that = (OutputPort) o;
-    return Objects.equals(getName(), that.getName())
+    return Objects.equals(getId(), that.getId())
+        && Objects.equals(getName(), that.getName())
         && Objects.equals(getDescription(), that.getDescription())
         && Objects.equals(getDataContract(), that.getDataContract())
         && Objects.equals(getDatasets(), that.getDatasets())
@@ -114,7 +130,7 @@ public final class OutputPort {
   @Override
   public int hashCode() {
     return Objects.hash(
-        getName(), getDescription(), getDataContract(), getDatasets(), getProperties());
+        getId(), getName(), getDescription(), getDataContract(), getDatasets(), getProperties());
   }
 
   /**
@@ -125,7 +141,9 @@ public final class OutputPort {
   @Override
   public String toString() {
     return "OutputPort{"
-        + "dataContract="
+        + "id="
+        + id
+        + ", dataContract="
         + dataContract
         + ", name='"
         + name
@@ -150,6 +168,8 @@ public final class OutputPort {
   /** Builder class for creating instances of OutputPort. */
   public static class Builder {
 
+    private ItemIdentifier id;
+
     private String name;
 
     private String description = null;
@@ -161,6 +181,17 @@ public final class OutputPort {
 
     /** The properties of the output port. */
     private Map<String, PropertyValue> properties = Collections.emptyMap();
+
+    /**
+     * Sets the identifier of the output port.
+     *
+     * @param id the identifier of the output port
+     * @return the builder instance
+     */
+    public Builder id(@NotNull ItemIdentifier id) {
+      this.id = id;
+      return this;
+    }
 
     /**
      * Sets the name of the output port.

--- a/src/main/java/zeenea/connector/field/Field.java
+++ b/src/main/java/zeenea/connector/field/Field.java
@@ -55,7 +55,7 @@ public class Field {
    * @param builder the builder used to create the Field instance
    */
   public Field(Field.Builder<?, ?> builder) {
-    this.id = Objects.requireNonNull(builder.identifier, "identifier");
+    this.id = Objects.requireNonNull(builder.id, "id");
     this.name = Objects.requireNonNull(builder.name, "name");
     this.dataType = builder.dataType;
     this.nativeType = builder.nativeType;
@@ -250,7 +250,7 @@ public class Field {
   public static class Builder<T, THIS extends Builder<T, ?>> {
 
     /** The item identifier associated with the field. */
-    private ItemIdentifier identifier;
+    private ItemIdentifier id;
 
     /** The name of the field. */
     private String name;
@@ -329,11 +329,11 @@ public class Field {
     /**
      * Sets the identifier associated with the field.
      *
-     * @param identifier the item identifier
+     * @param id the item identifier
      * @return the builder instance
      */
-    public THIS identifier(@NotNull ItemIdentifier identifier) {
-      this.identifier = identifier;
+    public THIS id(@NotNull ItemIdentifier id) {
+      this.id = id;
       return self();
     }
 

--- a/src/test/java/zeenea/connector/dataproduct/InputPortTest.java
+++ b/src/test/java/zeenea/connector/dataproduct/InputPortTest.java
@@ -13,6 +13,8 @@ class InputPortTest {
   @Test
   @DisplayName("InputPort builder should create input port")
   void shouldCreateInputPortWithBuilder() {
+    ItemIdentifier inputPortIdentifier =
+        ItemIdentifier.of(List.of(IdentificationProperty.of("id", "input-port-1")));
     ItemIdentifier input1 = ItemIdentifier.of(List.of(IdentificationProperty.of("name", "input1")));
     ItemIdentifier input2 = ItemIdentifier.of(List.of(IdentificationProperty.of("name", "input2")));
     ConnectionReferenceCode referenceCode = ConnectionReferenceCode.of("code");
@@ -25,12 +27,14 @@ class InputPortTest {
     List<ItemIdentifier> outputs = List.of(output1, output2);
     InputPort inputPort =
         InputPort.builder()
+            .id(inputPortIdentifier)
             .name("InputPort1")
             .description("Description1")
             .inputs(inputs)
             .outputs(outputs)
             .build();
     assertNotNull(inputPort);
+    assertEquals(inputPortIdentifier, inputPort.getId());
     assertEquals("InputPort1", inputPort.getName());
     assertEquals(Optional.of("Description1"), inputPort.getDescription());
     assertEquals(inputs, inputPort.getInputs());
@@ -52,6 +56,7 @@ class InputPortTest {
     List<ItemIdentifier> outputs = List.of(output1, output2);
     InputPort inputPort1 =
         InputPort.builder()
+            .id(ItemIdentifier.of(List.of(IdentificationProperty.of("id", "input-port-1"))))
             .name("InputPort1")
             .description("Description1")
             .inputs(inputs)
@@ -59,6 +64,7 @@ class InputPortTest {
             .build();
     InputPort inputPort2 =
         InputPort.builder()
+            .id(ItemIdentifier.of(List.of(IdentificationProperty.of("id", "input-port-1"))))
             .name("InputPort1")
             .description("Description1")
             .inputs(inputs)
@@ -84,6 +90,7 @@ class InputPortTest {
     List<ItemIdentifier> outputs2 = List.of(output2);
     InputPort inputPort1 =
         InputPort.builder()
+            .id(ItemIdentifier.of(List.of(IdentificationProperty.of("id", "input-port-1"))))
             .name("InputPort1")
             .description("Description1")
             .inputs(inputs)
@@ -91,12 +98,28 @@ class InputPortTest {
             .build();
     InputPort inputPort2 =
         InputPort.builder()
+            .id(ItemIdentifier.of(List.of(IdentificationProperty.of("id", "input-port-2"))))
             .name("InputPort2")
             .description("Description2")
             .inputs(inputs)
             .outputs(outputs2)
             .build();
     assertNotEquals(inputPort1, inputPort2);
+  }
+
+  @Test
+  @DisplayName("InputPort builder should fail with null id")
+  void builderShouldFailWithNullId() {
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            InputPort.builder()
+                .id(null)
+                .name("InputPort1")
+                .description("Description1")
+                .inputs(List.of())
+                .outputs(List.of())
+                .build());
   }
 
   @Test
@@ -109,6 +132,7 @@ class InputPortTest {
         NullPointerException.class,
         () ->
             InputPort.builder()
+                .id(ItemIdentifier.of(List.of(IdentificationProperty.of("id", "input-port-1"))))
                 .name("InputPort1")
                 .description("Description1")
                 .inputs(List.of(null))
@@ -127,6 +151,7 @@ class InputPortTest {
         NullPointerException.class,
         () ->
             InputPort.builder()
+                .id(ItemIdentifier.of(List.of(IdentificationProperty.of("id", "input-port-1"))))
                 .name("InputPort1")
                 .description("Description1")
                 .inputs(inputs)

--- a/src/test/java/zeenea/connector/dataproduct/OutputPortTest.java
+++ b/src/test/java/zeenea/connector/dataproduct/OutputPortTest.java
@@ -30,6 +30,7 @@ class OutputPortTest {
         Map.of("key1", PropertyValue.string("value1"), "key2", PropertyValue.string("value2"));
     OutputPort outputPort =
         OutputPort.builder()
+            .id(ItemIdentifier.of(List.of(IdentificationProperty.of("id", "output-port-1"))))
             .name("OutputPort1")
             .description("Description1")
             .dataContract(dataContract)
@@ -59,6 +60,7 @@ class OutputPortTest {
         Map.of("key1", PropertyValue.string("value1"), "key2", PropertyValue.string("value2"));
     OutputPort outputPort1 =
         OutputPort.builder()
+            .id(ItemIdentifier.of(List.of(IdentificationProperty.of("id", "output-port-1"))))
             .name("OutputPort1")
             .description("Description1")
             .dataContract(dataContract)
@@ -67,6 +69,7 @@ class OutputPortTest {
             .build();
     OutputPort outputPort2 =
         OutputPort.builder()
+            .id(ItemIdentifier.of(List.of(IdentificationProperty.of("id", "output-port-1"))))
             .name("OutputPort1")
             .description("Description1")
             .dataContract(dataContract)
@@ -102,6 +105,7 @@ class OutputPortTest {
         Map.of("key3", PropertyValue.string("value3"), "key4", PropertyValue.string("value4"));
     OutputPort outputPort1 =
         OutputPort.builder()
+            .id(ItemIdentifier.of(List.of(IdentificationProperty.of("id", "output-port-1"))))
             .name("OutputPort1")
             .description("Description1")
             .dataContract(dataContract1)
@@ -110,6 +114,7 @@ class OutputPortTest {
             .build();
     OutputPort outputPort2 =
         OutputPort.builder()
+            .id(ItemIdentifier.of(List.of(IdentificationProperty.of("id", "output-port-2"))))
             .name("OutputPort2")
             .description("Description2")
             .dataContract(dataContract2)
@@ -117,6 +122,32 @@ class OutputPortTest {
             .properties(properties2)
             .build();
     assertNotEquals(outputPort1, outputPort2);
+  }
+
+  @Test
+  @DisplayName("OutputPort builder should fail with null id")
+  void builderShouldFailWithNullId() {
+    DataContract dataContract = DataContract.of(DataContract.Type.Custom, "sourceValue");
+    Dataset dataset1 =
+        Dataset.builder()
+            .id(ItemIdentifier.of(List.of(IdentificationProperty.of("name", "dataset1"))))
+            .name("Dataset1")
+            .build();
+
+    List<Dataset> datasets = List.of(dataset1);
+    Map<String, PropertyValue> properties =
+        Map.of("key1", PropertyValue.string("value1"), "key2", PropertyValue.string("value2"));
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            OutputPort.builder()
+                .id(null)
+                .name("OutputPort1")
+                .description("Description1")
+                .dataContract(dataContract)
+                .datasets(datasets)
+                .properties(properties)
+                .build());
   }
 
   @Test
@@ -136,6 +167,7 @@ class OutputPortTest {
         NullPointerException.class,
         () ->
             OutputPort.builder()
+                .id(ItemIdentifier.of(List.of(IdentificationProperty.of("id", "output-port-1"))))
                 .name(null)
                 .description("Description1")
                 .dataContract(dataContract)
@@ -160,6 +192,7 @@ class OutputPortTest {
         NullPointerException.class,
         () ->
             OutputPort.builder()
+                .id(ItemIdentifier.of(List.of(IdentificationProperty.of("id", "output-port-1"))))
                 .name("OutputPort1")
                 .description("Description1")
                 .dataContract(null)
@@ -178,6 +211,7 @@ class OutputPortTest {
         NullPointerException.class,
         () ->
             OutputPort.builder()
+                .id(ItemIdentifier.of(List.of(IdentificationProperty.of("id", "output-port-1"))))
                 .name("OutputPort1")
                 .description("Description1")
                 .dataContract(dataContract)
@@ -201,6 +235,7 @@ class OutputPortTest {
         NullPointerException.class,
         () ->
             OutputPort.builder()
+                .id(ItemIdentifier.of(List.of(IdentificationProperty.of("id", "output-port-1"))))
                 .name("OutputPort1")
                 .description("Description1")
                 .dataContract(dataContract)

--- a/src/test/java/zeenea/connector/dataset/DatasetTest.java
+++ b/src/test/java/zeenea/connector/dataset/DatasetTest.java
@@ -19,7 +19,7 @@ class DatasetTest {
     List<Field> fields =
         List.of(
             Field.builder()
-                .identifier(ItemIdentifier.of(IdentificationProperty.of("key", "field")))
+                .id(ItemIdentifier.of(IdentificationProperty.of("key", "field")))
                 .name("FieldName")
                 .dataType(DataType.String)
                 .nativeType("String")
@@ -72,7 +72,7 @@ class DatasetTest {
     List<Field> fields =
         List.of(
             Field.builder()
-                .identifier(ItemIdentifier.of(IdentificationProperty.of("key", "field")))
+                .id(ItemIdentifier.of(IdentificationProperty.of("key", "field")))
                 .name("FieldName")
                 .dataType(DataType.String)
                 .nativeType("String")
@@ -136,7 +136,7 @@ class DatasetTest {
             .fields(
                 List.of(
                     Field.builder()
-                        .identifier(ItemIdentifier.of(IdentificationProperty.of("key", "field")))
+                        .id(ItemIdentifier.of(IdentificationProperty.of("key", "field")))
                         .name("FieldName")
                         .dataType(DataType.String)
                         .nativeType("String")

--- a/src/test/java/zeenea/connector/field/FieldTest.java
+++ b/src/test/java/zeenea/connector/field/FieldTest.java
@@ -24,7 +24,7 @@ class FieldTest {
             IdentificationProperty.of("key2", "value2"));
     Field field =
         Field.builder()
-            .identifier(identifier)
+            .id(identifier)
             .name("FieldName")
             .dataType(DataType.String)
             .nativeType("String")
@@ -57,7 +57,7 @@ class FieldTest {
             IdentificationProperty.of("key2", "value2"));
     Field field1 =
         Field.builder()
-            .identifier(identifier)
+            .id(identifier)
             .name("FieldName")
             .dataType(DataType.String)
             .nativeType("String")
@@ -69,7 +69,7 @@ class FieldTest {
             .build();
     Field field2 =
         Field.builder()
-            .identifier(identifier)
+            .id(identifier)
             .name("FieldName")
             .dataType(DataType.String)
             .nativeType("String")
@@ -100,7 +100,7 @@ class FieldTest {
             IdentificationProperty.of("key3", "value3"));
     Field field1 =
         Field.builder()
-            .identifier(identifier1)
+            .id(identifier1)
             .name("FieldName1")
             .dataType(DataType.String)
             .nativeType("String")
@@ -112,7 +112,7 @@ class FieldTest {
             .build();
     Field field2 =
         Field.builder()
-            .identifier(identifier2)
+            .id(identifier2)
             .name("FieldName2")
             .dataType(DataType.Integer)
             .nativeType("Integer")
@@ -138,7 +138,7 @@ class FieldTest {
         NullPointerException.class,
         () ->
             Field.builder()
-                .identifier(identifier)
+                .id(identifier)
                 .name(null)
                 .dataType(DataType.String)
                 .nativeType("String")
@@ -159,7 +159,7 @@ class FieldTest {
         NullPointerException.class,
         () ->
             Field.builder()
-                .identifier(null)
+                .id(null)
                 .name("FieldName")
                 .dataType(DataType.String)
                 .nativeType("String")
@@ -182,7 +182,7 @@ class FieldTest {
         NullPointerException.class,
         () ->
             Field.builder()
-                .identifier(identifier)
+                .id(identifier)
                 .name("FieldName")
                 .dataType(DataType.String)
                 .nativeType("String")

--- a/src/test/java/zeenea/connector/visualization/VisualizationTest.java
+++ b/src/test/java/zeenea/connector/visualization/VisualizationTest.java
@@ -20,7 +20,7 @@ class VisualizationTest {
     List<Field> fields =
         List.of(
             Field.builder()
-                .identifier(ItemIdentifier.of(IdentificationProperty.of("key", "field")))
+                .id(ItemIdentifier.of(IdentificationProperty.of("key", "field")))
                 .name("field")
                 .dataType(DataType.String)
                 .nativeType("String")
@@ -56,7 +56,7 @@ class VisualizationTest {
     List<Field> fields =
         List.of(
             Field.builder()
-                .identifier(ItemIdentifier.of(IdentificationProperty.of("key", "field")))
+                .id(ItemIdentifier.of(IdentificationProperty.of("key", "field")))
                 .name("field")
                 .dataType(DataType.String)
                 .nativeType("String")
@@ -98,7 +98,7 @@ class VisualizationTest {
     List<Field> fields =
         List.of(
             Field.builder()
-                .identifier(ItemIdentifier.of(IdentificationProperty.of("key", "field")))
+                .id(ItemIdentifier.of(IdentificationProperty.of("key", "field")))
                 .name("field")
                 .dataType(DataType.String)
                 .nativeType("String")
@@ -158,7 +158,7 @@ class VisualizationTest {
     List<Field> fields =
         List.of(
             Field.builder()
-                .identifier(ItemIdentifier.of(IdentificationProperty.of("key", "field")))
+                .id(ItemIdentifier.of(IdentificationProperty.of("key", "field")))
                 .name("field")
                 .dataType(DataType.String)
                 .nativeType("String")


### PR DESCRIPTION
[\[ZEE-6154\] Update from Source DataProduct](https://zeenea.atlassian.net/browse/ZEE-6145)

##### PR summary:

- ajoute `id` aux input et output ports
- en profite pour renommer `identifier` en `id` dans le builder de `Field`

##### Checklist for Developer:

- [x] Summary part has been documented
- [x] Reviewers have been requested
- [ ] Reviews & comments have been taken into consideration
- [x] Commits have been reworded and history cleaned

##### Checklist for Reviewer

- [ ] Code has been reviewed, commented and changes have been requested
- [ ] Reviews & comments have been taken into consideration