### PR TITLE
[ZEE-7496] Add datasetReferences(Collection) method to OutputPort builder

### DIFF
--- a/src/main/java/zeenea/connector/dataproduct/OutputPort.java
+++ b/src/main/java/zeenea/connector/dataproduct/OutputPort.java
@@ -398,6 +398,17 @@ public final class OutputPort {
      * @param datasetReferences the list of dataset references to add
      * @return the builder instance
      */
+    public Builder datasetReferences(Collection<ItemReference> datasetReferences) {
+      this.datasetReferences = List.copyOf(datasetReferences);
+      return this;
+    }
+
+    /**
+     * Set a list of dataset references that can be linked to the output port
+     *
+     * @param datasetReferences the list of dataset references to add
+     * @return the builder instance
+     */
     public Builder datasetReferences(ItemReference... datasetReferences) {
       this.datasetReferences = List.of(datasetReferences);
       return this;


### PR DESCRIPTION
JIRA issue: https://actian.atlassian.net/browse/ZEE-7496

##### PR summary:

- Add method `OutputPort.Builder.datasetReferences(Collection<ItemReference> datasetReferences)` alongside its varargs counterpart
  - This makes it homogeneous with other collection-related methods
  - Saves some characters when using the builder

##### Checklist for Developer:

- [x] Summary part has been documented
- [x] Reviewers have been requested
- [ ] Reviews & comments have been taken into consideration
- [ ] Commits have been reworded and history cleaned

##### Checklist for Reviewer

- [ ] Code has been reviewed, commented and changes have been requested
- [ ] Reviews & comments have been taken into consideration


 
