### PR TITLE
[ZEE-9665] Added PowerQueryReference and related classes

### DIFF
--- a/src/main/java/zeenea/connector/common/powerquery/Attribute.java
+++ b/src/main/java/zeenea/connector/common/powerquery/Attribute.java
@@ -1,0 +1,151 @@
+package zeenea.connector.common.powerquery;
+
+import java.util.Objects;
+import org.jetbrains.annotations.NotNull;
+import zeenea.connector.exception.ExceptionUtils;
+
+/**
+ * Represents an attribute of an ODBC data source definition. The name must be one of:
+ *
+ * <ul>
+ *   <li>host
+ *   <li>port
+ *   <li>database
+ *   <li>awsRegion
+ * </ul>
+ *
+ * Names are represented as strings rather than enums to allow for extensibility and to accommodate
+ * any additional attributes that may be needed in the future.
+ */
+public class Attribute {
+  /** The name of the attribute. */
+  @NotNull private final String name;
+
+  /** The value of the attribute. */
+  @NotNull private final String value;
+
+  /**
+   * Constructs an Attribute instance using the provided builder.
+   *
+   * @param builder the builder used to create the Attribute instance
+   */
+  private Attribute(Attribute.Builder builder) {
+    ExceptionUtils.requireNonNullOrEmpty("name", builder.name);
+    ExceptionUtils.requireNonNullOrEmpty("value", builder.value);
+    this.name = builder.name;
+    this.value = builder.value;
+  }
+
+  /**
+   * Creates a new Attribute instance with the specified name and value.
+   *
+   * @param name the name of the attribute
+   * @param value the value of the attribute
+   * @return a new Attribute instance
+   */
+  public static Attribute of(@NotNull String name, @NotNull String value) {
+    return builder().name(name).value(value).build();
+  }
+
+  /**
+   * Gets the name of the attribute.
+   *
+   * @return the name of the attribute
+   */
+  public @NotNull String getName() {
+    return name;
+  }
+
+  /**
+   * Gets the value of the attribute.
+   *
+   * @return the value of the attribute
+   */
+  public @NotNull String getValue() {
+    return value;
+  }
+
+  /**
+   * Creates a new builder for an Attribute instance.
+   *
+   * @return a new Builder instance
+   */
+  public static Attribute.Builder builder() {
+    return new Attribute.Builder();
+  }
+
+  /**
+   * Checks if this attribute is equal to another object.
+   *
+   * @param o the object to compare with
+   * @return true if this attribute is equal to the specified object, otherwise false
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Attribute that = (Attribute) o;
+    return Objects.equals(name, that.name) && Objects.equals(value, that.value);
+  }
+
+  /**
+   * Computes the hash code for this attribute.
+   *
+   * @return the hash code of this attribute
+   */
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, value);
+  }
+
+  /**
+   * Returns a string representation of this attribute.
+   *
+   * @return a string representation of this attribute
+   */
+  @Override
+  public String toString() {
+    return "Attribute{" + "name='" + name + "', value='" + value + "'}";
+  }
+
+  /** Builder class for creating instances of Attribute. */
+  public static class Builder {
+
+    /** The name of the attribute. */
+    private String name;
+
+    /** The value of the attribute. */
+    private String value;
+
+    /**
+     * Sets the name of the attribute.
+     *
+     * @param name the name of the attribute
+     * @return the Builder instance
+     */
+    public Attribute.Builder name(@NotNull String name) {
+      this.name = name;
+      return this;
+    }
+
+    /**
+     * Sets the value of the attribute.
+     *
+     * @param value the value of the attribute
+     * @return the Builder instance
+     */
+    public Attribute.Builder value(@NotNull String value) {
+      this.value = value;
+      return this;
+    }
+
+    /**
+     * Builds and returns the Attribute instance.
+     *
+     * @return the created Attribute instance
+     */
+    public Attribute build() {
+      return new Attribute(this);
+    }
+  }
+}

--- a/src/main/java/zeenea/connector/common/powerquery/OdbcDsn.java
+++ b/src/main/java/zeenea/connector/common/powerquery/OdbcDsn.java
@@ -3,8 +3,8 @@ package zeenea.connector.common.powerquery;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents an ODBC DSN definition. This is used to obtain the details of an ODBC data source when
@@ -41,7 +41,7 @@ public class OdbcDsn {
    * @return a new OdbcDsn instance
    */
   public static OdbcDsn of(
-      @NotNull String name, @NotNull OdbcEngine engine, @Nullable List<Attribute> attributes) {
+      @NotNull String name, @NotNull OdbcEngine engine, @NotNull List<Attribute> attributes) {
     return builder().name(name).engine(engine).attributes(attributes).build();
   }
 
@@ -53,7 +53,7 @@ public class OdbcDsn {
    * @return a new OdbcDsn instance
    */
   public static OdbcDsn of(@NotNull String name, @NotNull OdbcEngine engine) {
-    return of(name, engine, null);
+    return of(name, engine, List.of());
   }
 
   /**
@@ -81,6 +81,19 @@ public class OdbcDsn {
    */
   public @NotNull List<Attribute> getAttributes() {
     return attributes;
+  }
+
+  /**
+   * Gets a specific attribute
+   *
+   * @param name the name of the attribute
+   * @return the value of the attribute
+   */
+  public Optional<String> getAttribute(String name) {
+    return attributes.stream()
+        .filter(attribute -> attribute.getName().equals(name))
+        .map(Attribute::getValue)
+        .findFirst();
   }
 
   /**
@@ -146,7 +159,7 @@ public class OdbcDsn {
      * @param name the name of the data source
      * @return the Builder instance
      */
-    public OdbcDsn.Builder name(@Nullable String name) {
+    public OdbcDsn.Builder name(@NotNull String name) {
       this.name = name;
       return this;
     }
@@ -157,7 +170,7 @@ public class OdbcDsn {
      * @param engine the engine type for the data source
      * @return the Builder instance
      */
-    public OdbcDsn.Builder engine(@Nullable OdbcEngine engine) {
+    public OdbcDsn.Builder engine(@NotNull OdbcEngine engine) {
       this.engine = engine;
       return this;
     }
@@ -168,7 +181,7 @@ public class OdbcDsn {
      * @param attributes the list of attributes associated with the data source
      * @return the Builder instance
      */
-    public OdbcDsn.Builder attributes(@Nullable List<Attribute> attributes) {
+    public OdbcDsn.Builder attributes(@NotNull List<Attribute> attributes) {
       this.attributes = attributes;
       return this;
     }

--- a/src/main/java/zeenea/connector/common/powerquery/OdbcDsn.java
+++ b/src/main/java/zeenea/connector/common/powerquery/OdbcDsn.java
@@ -1,0 +1,185 @@
+package zeenea.connector.common.powerquery;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Represents an ODBC DSN definition. This is used to obtain the details of an ODBC data source when
+ * one is used within a Power Query. This makes it possible to establish lineage to the source
+ * dataset.
+ */
+public class OdbcDsn {
+  /** The name of the data source */
+  @NotNull private final String name;
+
+  /** The engine type for the data source */
+  @NotNull private final OdbcEngine engine;
+
+  /** The list of attributes associated with the data source */
+  @NotNull private final List<Attribute> attributes;
+
+  /**
+   * Constructs an OdbcDsn instance using the provided builder.
+   *
+   * @param builder the builder used to create the OdbcDsn instance
+   */
+  private OdbcDsn(OdbcDsn.Builder builder) {
+    this.name = Objects.requireNonNull(builder.name, "name");
+    this.engine = Objects.requireNonNull(builder.engine, "engine");
+    this.attributes = builder.attributes;
+  }
+
+  /**
+   * Creates a new OdbcDsn instance.
+   *
+   * @param name the name of the data source
+   * @param engine the type of engine defined by the data source
+   * @param attributes the list of attributes defined by the data source
+   * @return a new OdbcDsn instance
+   */
+  public static OdbcDsn of(
+      @NotNull String name, @NotNull OdbcEngine engine, @Nullable List<Attribute> attributes) {
+    return builder().name(name).engine(engine).attributes(attributes).build();
+  }
+
+  /**
+   * Creates a new OdbcDsn instance with an empty list of attributes.
+   *
+   * @param name the name of the data source
+   * @param engine the type of engine defined by the data source
+   * @return a new OdbcDsn instance
+   */
+  public static OdbcDsn of(@NotNull String name, @NotNull OdbcEngine engine) {
+    return of(name, engine, null);
+  }
+
+  /**
+   * Gets the name of the data source.
+   *
+   * @return the name of the data source.
+   */
+  public @NotNull String getName() {
+    return name;
+  }
+
+  /**
+   * Gets the engine defined by the data source.
+   *
+   * @return the engine defined by the data source.
+   */
+  public @NotNull OdbcEngine getEngine() {
+    return engine;
+  }
+
+  /**
+   * Gets the attributes defined by the data source.
+   *
+   * @return the attributes defined by the data source.
+   */
+  public @NotNull List<Attribute> getAttributes() {
+    return attributes;
+  }
+
+  /**
+   * Creates a new builder for the OdbcDsn class.
+   *
+   * @return a new Builder instance
+   */
+  public static OdbcDsn.Builder builder() {
+    return new OdbcDsn.Builder();
+  }
+
+  /**
+   * Checks if this OdbcDsn is equal to another object.
+   *
+   * @param o the object to compare with
+   * @return true if this OdbcDsn is equal to the specified object, otherwise false
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    OdbcDsn that = (OdbcDsn) o;
+    return Objects.equals(name, that.name)
+        && Objects.equals(engine, that.engine)
+        && Objects.equals(attributes, that.attributes);
+  }
+
+  /**
+   * Computes the hash code for this OdbcDsn.
+   *
+   * @return the hash code of this OdbcDsn
+   */
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, engine, attributes);
+  }
+
+  /**
+   * Returns a string representation of this OdbcDsn.
+   *
+   * @return a string representation of this OdbcDsn
+   */
+  @Override
+  public String toString() {
+    return "OdbcDsn{" + "name=" + name + ", engine=" + engine + ", attributes=" + attributes + "}";
+  }
+
+  /** Builder class for creating instances of OdbcDsn. */
+  public static class Builder {
+
+    /** The name of the data source. */
+    private String name;
+
+    /** The engine type for the data source */
+    private OdbcEngine engine;
+
+    /** The list of attributes associated with the data source */
+    private List<Attribute> attributes = new ArrayList<>();
+
+    /**
+     * Sets the name of the data source.
+     *
+     * @param name the name of the data source
+     * @return the Builder instance
+     */
+    public OdbcDsn.Builder name(@Nullable String name) {
+      this.name = name;
+      return this;
+    }
+
+    /**
+     * Sets the engine type for the data source.
+     *
+     * @param engine the engine type for the data source
+     * @return the Builder instance
+     */
+    public OdbcDsn.Builder engine(@Nullable OdbcEngine engine) {
+      this.engine = engine;
+      return this;
+    }
+
+    /**
+     * Sets the list of attributes associated with the data source.
+     *
+     * @param attributes the list of attributes associated with the data source
+     * @return the Builder instance
+     */
+    public OdbcDsn.Builder attributes(@Nullable List<Attribute> attributes) {
+      this.attributes = attributes;
+      return this;
+    }
+
+    /**
+     * Builds and returns a OdbcDsn instance.
+     *
+     * @return the created OdbcDsn instance
+     */
+    public OdbcDsn build() {
+      return new OdbcDsn(this);
+    }
+  }
+}

--- a/src/main/java/zeenea/connector/common/powerquery/OdbcEngine.java
+++ b/src/main/java/zeenea/connector/common/powerquery/OdbcEngine.java
@@ -1,0 +1,44 @@
+package zeenea.connector.common.powerquery;
+
+import java.util.Arrays;
+
+/** Enum representing possible ODBC engine providers. */
+public enum OdbcEngine {
+  ATHENA("athena"),
+  BIGQUERY("bigquery"),
+  DENODO("denodo"),
+  ORACLE("oracle"),
+  REDSHIFT("redshift"),
+  SNOWFLAKE("snowflake"),
+  SQLSERVER("sqlserver"),
+  TERADATA("teradata"),
+  UNKNOWN("unknown");
+
+  private final String odbcEngine;
+
+  OdbcEngine(String odbcEngine) {
+    this.odbcEngine = odbcEngine;
+  }
+
+  public String getOdbcEngine() {
+    return odbcEngine;
+  }
+
+  /**
+   * Returns the OdbcEngine associated with the given name. Returns UNKNOWN if the name is null or
+   * not found.
+   *
+   * @param name The name to look up
+   * @return The matching OdbcEngine or UNKNOWN
+   */
+  public static OdbcEngine fromName(String name) {
+    if (name == null) {
+      return UNKNOWN;
+    }
+
+    return Arrays.stream(values())
+        .filter(dialect -> dialect.odbcEngine.equalsIgnoreCase(name))
+        .findFirst()
+        .orElse(UNKNOWN);
+  }
+}

--- a/src/main/java/zeenea/connector/common/powerquery/PowerQueryReference.java
+++ b/src/main/java/zeenea/connector/common/powerquery/PowerQueryReference.java
@@ -1,0 +1,152 @@
+package zeenea.connector.common.powerquery;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Represents a Power Query linked to an {@link zeenea.connector.Item} that will generate lineage
+ * reference based on the query.
+ */
+public final class PowerQueryReference {
+  /** The Power Query for the item. */
+  @NotNull private final String powerQuery;
+
+  /** ODBC DSN details to resolve lineage for ODBC sources */
+  @NotNull private final List<OdbcDsn> dsns;
+
+  /**
+   * Constructs an QueryReference instance using the provided builder.
+   *
+   * @param builder the builder used to create the QueryReference instance
+   */
+  private PowerQueryReference(PowerQueryReference.Builder builder) {
+    this.powerQuery = Objects.requireNonNull(builder.powerQuery, "powerQuery");
+    this.dsns = builder.dsns != null ? builder.dsns : List.of();
+  }
+
+  /**
+   * Creates a new PowerQueryReference instance with the specified Power Query, and optional DSNs.
+   *
+   * @param powerQuery the query for the item
+   * @param dsns the list of ODBC DSN definitions
+   * @return a new PowerQueryReference instance
+   */
+  public static PowerQueryReference of(@NotNull String powerQuery, @Nullable List<OdbcDsn> dsns) {
+    return builder().powerQuery(powerQuery).dsns(dsns).build();
+  }
+
+  /**
+   * Creates a new PowerQueryReference instance with the specified Power Query, without any DSNs.
+   *
+   * @param powerQuery the query for the item
+   * @return a new QueryReference instance
+   */
+  public static PowerQueryReference of(@NotNull String powerQuery) {
+    return of(powerQuery, null);
+  }
+
+  /**
+   * Gets the Power Query for the item.
+   *
+   * @return the Power Query for the item
+   */
+  public @NotNull String getPowerQuery() {
+    return powerQuery;
+  }
+
+  /**
+   * Gets the ODBC DSNs for the item.
+   *
+   * @return the ODBC DSNs for the item.
+   */
+  public @NotNull List<OdbcDsn> getDsns() {
+    return dsns;
+  }
+
+  /**
+   * Creates a new builder for the PowerQueryReference class.
+   *
+   * @return a new Builder instance
+   */
+  public static PowerQueryReference.Builder builder() {
+    return new PowerQueryReference.Builder();
+  }
+
+  /**
+   * Checks if this PowerQueryReference is equal to another object.
+   *
+   * @param o the object to compare with
+   * @return true if this PowerQueryReference is equal to the specified object, otherwise false
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    PowerQueryReference that = (PowerQueryReference) o;
+    return Objects.equals(powerQuery, that.powerQuery) && Objects.equals(dsns, that.dsns);
+  }
+
+  /**
+   * Computes the hash code for this PowerQueryReference.
+   *
+   * @return the hash code of this PowerQueryReference
+   */
+  @Override
+  public int hashCode() {
+    return Objects.hash(powerQuery, dsns);
+  }
+
+  /**
+   * Returns a string representation of this PowerQueryReference.
+   *
+   * @return a string representation of this PowerQueryReference
+   */
+  @Override
+  public String toString() {
+    return "PowerQueryReference{" + "powerQuery=" + powerQuery + ", dsns=" + dsns + "}";
+  }
+
+  /** Builder class for creating instances of PowerQueryReference. */
+  public static class Builder {
+
+    /** The Power Query for the item. */
+    private String powerQuery;
+
+    /** The list of DSNs. */
+    private List<OdbcDsn> dsns = new ArrayList<>();
+
+    /**
+     * Sets the Power Query for the item.
+     *
+     * @param powerQuery the query for the item
+     * @return the Builder instance
+     */
+    public PowerQueryReference.Builder powerQuery(@Nullable String powerQuery) {
+      this.powerQuery = powerQuery;
+      return this;
+    }
+
+    /**
+     * Sets the list of DSNs.
+     *
+     * @param dsns the list of DSNs
+     * @return the Builder instance
+     */
+    public PowerQueryReference.Builder dsns(@Nullable List<OdbcDsn> dsns) {
+      this.dsns = dsns;
+      return this;
+    }
+
+    /**
+     * Builds and returns a PowerQueryReference instance.
+     *
+     * @return the created PowerQueryReference instance
+     */
+    public PowerQueryReference build() {
+      return new PowerQueryReference(this);
+    }
+  }
+}

--- a/src/main/java/zeenea/connector/dataset/Dataset.java
+++ b/src/main/java/zeenea/connector/dataset/Dataset.java
@@ -8,6 +8,7 @@ import zeenea.connector.Item;
 import zeenea.connector.common.ItemIdentifier;
 import zeenea.connector.common.ItemReference;
 import zeenea.connector.common.QueryReference;
+import zeenea.connector.common.powerquery.PowerQueryReference;
 import zeenea.connector.exception.ExceptionUtils;
 import zeenea.connector.field.Field;
 
@@ -46,6 +47,14 @@ public final class Dataset extends Item {
   @NotNull private final List<QueryReference> sourceQueries;
 
   /**
+   * The list of source Power Queries associated with the dataset.
+   *
+   * <p>Used to declare upstream dataset lineage by referencing PowerQueryReference of source
+   * datasets.
+   */
+  @NotNull private final List<PowerQueryReference> sourcePowerQueries;
+
+  /**
    * Indicates whether this dataset is being handled via the new inventory mode.
    *
    * <p>When {@code true}, it signifies that the dataset was imported from a visualization context
@@ -66,12 +75,14 @@ public final class Dataset extends Item {
     ExceptionUtils.requireNonNull("foreignKeys", builder.foreignKeys);
     ExceptionUtils.requireNonNull("sourceDatasets", builder.sourceDatasets);
     ExceptionUtils.requireNonNull("sourceQueries", builder.sourceQueries);
+    ExceptionUtils.requireNonNull("powerQueries", builder.sourcePowerQueries);
     this.fields = List.copyOf(builder.fields);
     this.primaryKeys = List.copyOf(builder.primaryKeys);
     this.primaryKeyIdentifiers = List.copyOf(builder.primaryKeyIdentifiers);
     this.foreignKeys = List.copyOf(builder.foreignKeys);
     this.sourceDatasets = List.copyOf(builder.sourceDatasets);
     this.sourceQueries = List.copyOf(builder.sourceQueries);
+    this.sourcePowerQueries = List.copyOf(builder.sourcePowerQueries);
     this.nestedImport = builder.nestedImport;
   }
 
@@ -134,6 +145,15 @@ public final class Dataset extends Item {
   }
 
   /**
+   * Gets the list of source Power Query references.
+   *
+   * @return the list of source Power Query references
+   */
+  public @NotNull List<PowerQueryReference> getSourcePowerQueries() {
+    return sourcePowerQueries;
+  }
+
+  /**
    * Checks if the dataset is imported via the new inventory mode.
    *
    * @return {@code true} if the dataset is a nested import from a visualization; {@code false}
@@ -165,6 +185,7 @@ public final class Dataset extends Item {
         && Objects.equals(foreignKeys, dataset.foreignKeys)
         && Objects.equals(sourceDatasets, dataset.sourceDatasets)
         && Objects.equals(sourceQueries, dataset.sourceQueries)
+        && Objects.equals(sourcePowerQueries, dataset.sourcePowerQueries)
         && Objects.equals(nestedImport, dataset.nestedImport);
   }
 
@@ -187,6 +208,7 @@ public final class Dataset extends Item {
         foreignKeys,
         sourceDatasets,
         sourceQueries,
+        sourcePowerQueries,
         nestedImport);
   }
 
@@ -220,6 +242,8 @@ public final class Dataset extends Item {
         + sourceDatasets
         + ", sourceQueries="
         + sourceQueries
+        + ", sourcePowerQueries="
+        + sourcePowerQueries
         + ", nestedImport="
         + nestedImport
         + '}';
@@ -258,6 +282,9 @@ public final class Dataset extends Item {
 
     /** The list of source queries for the dataset. */
     private List<QueryReference> sourceQueries = new ArrayList<>();
+
+    /** The list of source Power Queries for the dataset. */
+    private List<PowerQueryReference> sourcePowerQueries = new ArrayList<>();
 
     /** Indicates whether this dataset is being handled via the new inventory mode. */
     private boolean nestedImport = false;
@@ -392,13 +419,35 @@ public final class Dataset extends Item {
     }
 
     /**
-     * Sets the source query references for the DataProcess.
+     * Sets the source query references for the dataset.
      *
      * @param sourceQueries the source query references
      * @return this Builder instance
      */
     public Builder sourceQueries(QueryReference... sourceQueries) {
       this.sourceQueries = List.of(sourceQueries);
+      return this;
+    }
+
+    /**
+     * Sets the list of source Power Queries for the dataset.
+     *
+     * @param sourcePowerQueries the list of source Power Queries
+     * @return the builder instance
+     */
+    public Builder sourcePowerQueries(@NotNull List<PowerQueryReference> sourcePowerQueries) {
+      this.sourcePowerQueries = List.copyOf(sourcePowerQueries);
+      return this;
+    }
+
+    /**
+     * Sets the source Power Query references for the dataset.
+     *
+     * @param sourcePowerQueries the source Power Query references
+     * @return this Builder instance
+     */
+    public Builder sourcePowerQueries(PowerQueryReference... sourcePowerQueries) {
+      this.sourcePowerQueries = List.of(sourcePowerQueries);
       return this;
     }
 

--- a/src/test/java/zeenea/connector/common/powerquery/OdbcDsnTest.java
+++ b/src/test/java/zeenea/connector/common/powerquery/OdbcDsnTest.java
@@ -1,0 +1,184 @@
+package zeenea.connector.common.powerquery;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class OdbcDsnTest {
+
+  private static final String DEFAULT_DSN_NAME = "testDSN";
+  private static final OdbcEngine DEFAULT_ENGINE = OdbcEngine.SQLSERVER;
+
+  @Test
+  @DisplayName("OdbcDsn factory should create ODBC DSN with attributes")
+  void shouldCreateOdbcDsnWithAttributes() {
+    List<Attribute> attributes =
+        List.of(Attribute.of("host", "localhost"), Attribute.of("port", "1433"));
+    OdbcDsn odbcDsn = OdbcDsn.of(DEFAULT_DSN_NAME, DEFAULT_ENGINE, attributes);
+
+    assertNotNull(odbcDsn);
+    assertEquals(DEFAULT_DSN_NAME, odbcDsn.getName());
+    assertEquals(DEFAULT_ENGINE, odbcDsn.getEngine());
+    assertEquals(attributes, odbcDsn.getAttributes());
+  }
+
+  @Test
+  @DisplayName("OdbcDsn factory should create ODBC DSN without attributes")
+  void shouldCreateOdbcDsnWithoutAttributes() {
+    OdbcDsn odbcDsn = OdbcDsn.of(DEFAULT_DSN_NAME, DEFAULT_ENGINE);
+
+    assertNotNull(odbcDsn);
+    assertEquals(DEFAULT_DSN_NAME, odbcDsn.getName());
+    assertEquals(DEFAULT_ENGINE, odbcDsn.getEngine());
+    assertEquals(List.of(), odbcDsn.getAttributes());
+  }
+
+  @Test
+  @DisplayName("OdbcDsn should be equal to another with same properties")
+  void shouldBeEqualToAnotherWithSameProperties() {
+    List<Attribute> attributes =
+        List.of(Attribute.of("host", "localhost"), Attribute.of("port", "1433"));
+    OdbcDsn odbcDsn1 = OdbcDsn.of(DEFAULT_DSN_NAME, DEFAULT_ENGINE, attributes);
+    OdbcDsn odbcDsn2 = OdbcDsn.of(DEFAULT_DSN_NAME, DEFAULT_ENGINE, attributes);
+
+    assertEquals(odbcDsn1, odbcDsn2);
+    assertEquals(odbcDsn1.hashCode(), odbcDsn2.hashCode());
+  }
+
+  @Test
+  @DisplayName("OdbcDsn should not be equal to another with different name")
+  void shouldNotBeEqualToAnotherWithDifferentName() {
+    List<Attribute> attributes =
+        List.of(Attribute.of("host", "localhost"), Attribute.of("port", "1433"));
+    OdbcDsn odbcDsn1 = OdbcDsn.of("testDSN1", DEFAULT_ENGINE, attributes);
+    OdbcDsn odbcDsn2 = OdbcDsn.of("testDSN2", DEFAULT_ENGINE, attributes);
+
+    assertNotEquals(odbcDsn1, odbcDsn2);
+  }
+
+  @Test
+  @DisplayName("OdbcDsn should not be equal to another with different engine")
+  void shouldNotBeEqualToAnotherWithDifferentEngine() {
+    List<Attribute> attributes =
+        List.of(Attribute.of("host", "localhost"), Attribute.of("port", "1433"));
+    OdbcDsn odbcDsn1 = OdbcDsn.of(DEFAULT_DSN_NAME, OdbcEngine.SQLSERVER, attributes);
+    OdbcDsn odbcDsn2 = OdbcDsn.of(DEFAULT_DSN_NAME, OdbcEngine.ORACLE, attributes);
+
+    assertNotEquals(odbcDsn1, odbcDsn2);
+  }
+
+  @Test
+  @DisplayName("OdbcDsn should not be equal to another with different attributes")
+  void shouldNotBeEqualToAnotherWithDifferentAttributes() {
+    OdbcDsn odbcDsn1 =
+        OdbcDsn.of(
+            DEFAULT_DSN_NAME,
+            DEFAULT_ENGINE,
+            List.of(Attribute.of("host", "localhost"), Attribute.of("port", "1433")));
+    OdbcDsn odbcDsn2 =
+        OdbcDsn.of(
+            DEFAULT_DSN_NAME,
+            DEFAULT_ENGINE,
+            List.of(Attribute.of("host", "remotehost"), Attribute.of("port", "5432")));
+
+    assertNotEquals(odbcDsn1, odbcDsn2);
+  }
+
+  @Test
+  @DisplayName("OdbcDsn should not be equal to another with different attribute count")
+  void shouldNotBeEqualToAnotherWithDifferentAttributeCount() {
+    OdbcDsn odbcDsn1 =
+        OdbcDsn.of(
+            DEFAULT_DSN_NAME,
+            DEFAULT_ENGINE,
+            List.of(Attribute.of("host", "localhost"), Attribute.of("port", "1433")));
+    OdbcDsn odbcDsn2 =
+        OdbcDsn.of(DEFAULT_DSN_NAME, DEFAULT_ENGINE, List.of(Attribute.of("host", "localhost")));
+
+    assertNotEquals(odbcDsn1, odbcDsn2);
+  }
+
+  @Test
+  @DisplayName("OdbcDsn should not be equal to null")
+  void shouldNotBeEqualToNull() {
+    OdbcDsn odbcDsn = OdbcDsn.of(DEFAULT_DSN_NAME, DEFAULT_ENGINE);
+    assertNotEquals(null, odbcDsn);
+  }
+
+  @Test
+  @DisplayName("OdbcDsn builder should create instance with all properties")
+  void shouldCreateOdbcDsnWithBuilder() {
+    List<Attribute> attributes =
+        List.of(Attribute.of("host", "localhost"), Attribute.of("port", "1433"));
+    OdbcDsn odbcDsn =
+        OdbcDsn.builder()
+            .name(DEFAULT_DSN_NAME)
+            .engine(DEFAULT_ENGINE)
+            .attributes(attributes)
+            .build();
+
+    assertNotNull(odbcDsn);
+    assertEquals(DEFAULT_DSN_NAME, odbcDsn.getName());
+    assertEquals(DEFAULT_ENGINE, odbcDsn.getEngine());
+    assertEquals(attributes, odbcDsn.getAttributes());
+  }
+
+  @Test
+  @DisplayName("OdbcDsn builder should initialize empty attributes list")
+  void shouldCreateOdbcDsnWithBuilderEmptyAttributes() {
+    OdbcDsn odbcDsn = OdbcDsn.builder().name(DEFAULT_DSN_NAME).engine(DEFAULT_ENGINE).build();
+
+    assertNotNull(odbcDsn);
+    assertEquals(DEFAULT_DSN_NAME, odbcDsn.getName());
+    assertEquals(DEFAULT_ENGINE, odbcDsn.getEngine());
+    assertEquals(List.of(), odbcDsn.getAttributes());
+  }
+
+  @Test
+  @DisplayName("OdbcDsn should get attribute by name")
+  void shouldGetAttributeByName() {
+    List<Attribute> attributes =
+        List.of(Attribute.of("host", "localhost"), Attribute.of("port", "1433"));
+    OdbcDsn odbcDsn = OdbcDsn.of(DEFAULT_DSN_NAME, DEFAULT_ENGINE, attributes);
+
+    assertEquals(Optional.of("localhost"), odbcDsn.getAttribute("host"));
+  }
+
+  @Test
+  @DisplayName("OdbcDsn should return empty optional for non-existent attribute")
+  void shouldReturnEmptyOptionalForNonExistentAttribute() {
+    List<Attribute> attributes =
+        List.of(Attribute.of("host", "localhost"), Attribute.of("port", "1433"));
+    OdbcDsn odbcDsn = OdbcDsn.of(DEFAULT_DSN_NAME, DEFAULT_ENGINE, attributes);
+
+    assertEquals(Optional.empty(), odbcDsn.getAttribute("database"));
+  }
+
+  @Test
+  @DisplayName("OdbcDsn should return empty optional when attributes list is empty")
+  void shouldReturnEmptyOptionalWhenAttributesListEmpty() {
+    OdbcDsn odbcDsn = OdbcDsn.of(DEFAULT_DSN_NAME, DEFAULT_ENGINE);
+
+    assertEquals(Optional.empty(), odbcDsn.getAttribute("host"));
+  }
+
+  @Test
+  @DisplayName("OdbcDsn should work with all standard attribute names")
+  void shouldWorkWithStandardAttributeNames() {
+    List<Attribute> attributes =
+        List.of(
+            Attribute.of("host", "db.example.com"),
+            Attribute.of("port", "5432"),
+            Attribute.of("database", "mydb"),
+            Attribute.of("awsRegion", "us-east-1"));
+    OdbcDsn odbcDsn = OdbcDsn.of("postgres", OdbcEngine.REDSHIFT, attributes);
+
+    assertEquals("db.example.com", odbcDsn.getAttribute("host").orElse(null));
+    assertEquals("5432", odbcDsn.getAttribute("port").orElse(null));
+    assertEquals("mydb", odbcDsn.getAttribute("database").orElse(null));
+    assertEquals("us-east-1", odbcDsn.getAttribute("awsRegion").orElse(null));
+  }
+}

--- a/src/test/java/zeenea/connector/common/powerquery/PowerQueryReferenceTest.java
+++ b/src/test/java/zeenea/connector/common/powerquery/PowerQueryReferenceTest.java
@@ -8,58 +8,93 @@ import org.junit.jupiter.api.Test;
 
 class PowerQueryReferenceTest {
 
+  private static final String DEFAULT_POWER_QUERY =
+      "let source = Odbc.Query(\"dsn=testDSN\", \"SELECT * FROM table\") in source";
+
   @Test
   @DisplayName("PowerQueryReference factory should create power query reference")
   void shouldCreatePowerQueryReference() {
-    OdbcDsn odbcDsn =
-        OdbcDsn.of(
-            "testDSN",
-            OdbcEngine.SQLSERVER,
-            List.of(Attribute.of("host", "localhost"), Attribute.of("port", "1433")));
+    OdbcDsn odbcDsn = getOdbcDsn("testDSN");
     PowerQueryReference powerQueryReference =
-        PowerQueryReference.of(
-            "let source = Odbc.Query(\"dsn=testDSN\", \"SELECT * FROM table\") in source",
-            List.of(odbcDsn));
+        PowerQueryReference.of(DEFAULT_POWER_QUERY, List.of(odbcDsn));
     assertNotNull(powerQueryReference);
-    assertEquals(
-        "let source = Odbc.Query(\"dsn=testDSN\", \"SELECT * FROM table\") in source",
-        powerQueryReference.getPowerQuery());
+    assertEquals(DEFAULT_POWER_QUERY, powerQueryReference.getPowerQuery());
     assertEquals(List.of(odbcDsn), powerQueryReference.getDsns());
   }
 
   @Test
   @DisplayName("PowerQueryReference should be equal to another with same properties")
   void shouldBeEqualToAnotherWithSameProperties() {
-    OdbcDsn odbcDsn =
-        OdbcDsn.of(
-            "testDSN",
-            OdbcEngine.SQLSERVER,
-            List.of(Attribute.of("host", "localhost"), Attribute.of("port", "1433")));
+    OdbcDsn odbcDsn = getOdbcDsn("testDSN");
     PowerQueryReference powerQueryReference1 =
-        PowerQueryReference.of(
-            "let source = Odbc.Query(\"dsn=testDSN\", \"SELECT * FROM table\") in source",
-            List.of(odbcDsn));
+        PowerQueryReference.of(DEFAULT_POWER_QUERY, List.of(odbcDsn));
     PowerQueryReference powerQueryReference2 =
-        PowerQueryReference.of(
-            "let source = Odbc.Query(\"dsn=testDSN\", \"SELECT * FROM table\") in source",
-            List.of(odbcDsn));
+        PowerQueryReference.of(DEFAULT_POWER_QUERY, List.of(odbcDsn));
     assertEquals(powerQueryReference1, powerQueryReference2);
     assertEquals(powerQueryReference1.hashCode(), powerQueryReference2.hashCode());
   }
 
   @Test
-  @DisplayName("PowerQueryReference should not be equal to another with different properties")
-  void shouldNotBeEqualToAnotherWithDifferentProperties() {
+  @DisplayName("PowerQueryReference should not be equal to another with different name")
+  void shouldNotBeEqualToAnotherWithDifferentName() {
+    OdbcDsn odbcDsn1 = getOdbcDsn("testDSN1");
+    OdbcDsn odbcDsn2 = getOdbcDsn("testDSN2");
+    PowerQueryReference powerQueryReference1 =
+        PowerQueryReference.of(
+            "let source = Odbc.Query(\"dsn=testDSN1\", \"SELECT * FROM table\") in source",
+            List.of(odbcDsn1));
+    PowerQueryReference powerQueryReference2 =
+        PowerQueryReference.of(
+            "let source = Odbc.Query(\"dsn=testDSN2\", \"SELECT * FROM table\") in source",
+            List.of(odbcDsn2));
+    assertNotEquals(powerQueryReference1, powerQueryReference2);
+  }
+
+  @Test
+  @DisplayName("PowerQueryReference should not be equal to another with different engine")
+  void shouldNotBeEqualToAnotherWithDifferentEngines() {
+    OdbcDsn odbcDsn1 = getOdbcDsn("testDSN", OdbcEngine.SQLSERVER);
+    OdbcDsn odbcDsn2 = getOdbcDsn("testDSN", OdbcEngine.ORACLE);
+    PowerQueryReference powerQueryReference1 =
+        PowerQueryReference.of(
+            "let source = Odbc.Query(\"dsn=testDSN1\", \"SELECT * FROM table\") in source",
+            List.of(odbcDsn1));
+    PowerQueryReference powerQueryReference2 =
+        PowerQueryReference.of(
+            "let source = Odbc.Query(\"dsn=testDSN2\", \"SELECT * FROM table\") in source",
+            List.of(odbcDsn2));
+    assertNotEquals(powerQueryReference1, powerQueryReference2);
+  }
+
+  @Test
+  @DisplayName("PowerQueryReference should not be equal to another with different attributes")
+  void shouldNotBeEqualToAnotherWithDifferentAttributes() {
     OdbcDsn odbcDsn1 =
         OdbcDsn.of(
-            "testDSN1",
+            "testDSN",
             OdbcEngine.SQLSERVER,
             List.of(Attribute.of("host", "localhost"), Attribute.of("port", "1433")));
     OdbcDsn odbcDsn2 =
         OdbcDsn.of(
-            "testDSN2",
-            OdbcEngine.ORACLE,
-            List.of(Attribute.of("host", "remotehost"), Attribute.of("port", "1521")));
+            "testDSN",
+            OdbcEngine.SQLSERVER,
+            List.of(Attribute.of("host", "localhost"), Attribute.of("port", "5000")));
+    PowerQueryReference powerQueryReference1 =
+        PowerQueryReference.of(
+            "let source = Odbc.Query(\"dsn=testDSN1\", \"SELECT * FROM table\") in source",
+            List.of(odbcDsn1));
+    PowerQueryReference powerQueryReference2 =
+        PowerQueryReference.of(
+            "let source = Odbc.Query(\"dsn=testDSN2\", \"SELECT * FROM table\") in source",
+            List.of(odbcDsn2));
+    assertNotEquals(powerQueryReference1, powerQueryReference2);
+  }
+
+  @Test
+  @DisplayName("PowerQueryReference should not be equal to another with different Power Queries")
+  void shouldNotBeEqualToAnotherWithDifferentPowerQuery() {
+    OdbcDsn odbcDsn1 = getOdbcDsn("testDSN");
+    OdbcDsn odbcDsn2 = getOdbcDsn("testDSN");
     PowerQueryReference powerQueryReference1 =
         PowerQueryReference.of(
             "let source = Odbc.Query(\"dsn=testDSN1\", \"SELECT * FROM table1\") in source",
@@ -105,14 +140,11 @@ class PowerQueryReferenceTest {
             List.of(Attribute.of("host", "localhost"), Attribute.of("port", "1433")));
     PowerQueryReference powerQueryReference =
         PowerQueryReference.builder()
-            .powerQuery(
-                "let source = Odbc.Query(\"dsn=testDSN\", \"SELECT * FROM table\") in source")
+            .powerQuery(DEFAULT_POWER_QUERY)
             .dsns(List.of(odbcDsn))
             .build();
     assertNotNull(powerQueryReference);
-    assertEquals(
-        "let source = Odbc.Query(\"dsn=testDSN\", \"SELECT * FROM table\") in source",
-        powerQueryReference.getPowerQuery());
+    assertEquals(DEFAULT_POWER_QUERY, powerQueryReference.getPowerQuery());
     assertEquals(List.of(odbcDsn), powerQueryReference.getDsns());
   }
 
@@ -129,5 +161,17 @@ class PowerQueryReferenceTest {
         "let source = Excel.Workbook(File.Contents(\"C:\\data.xlsx\")) in source",
         powerQueryReference.getPowerQuery());
     assertEquals(List.of(), powerQueryReference.getDsns());
+  }
+
+  private static OdbcDsn getOdbcDsn(String name) {
+    return OdbcDsn.of(
+        name,
+        OdbcEngine.SQLSERVER,
+        List.of(Attribute.of("host", "localhost"), Attribute.of("port", "1433")));
+  }
+
+  private static OdbcDsn getOdbcDsn(String name, OdbcEngine engine) {
+    return OdbcDsn.of(
+        name, engine, List.of(Attribute.of("host", "localhost"), Attribute.of("port", "1433")));
   }
 }

--- a/src/test/java/zeenea/connector/common/powerquery/PowerQueryReferenceTest.java
+++ b/src/test/java/zeenea/connector/common/powerquery/PowerQueryReferenceTest.java
@@ -1,0 +1,133 @@
+package zeenea.connector.common.powerquery;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PowerQueryReferenceTest {
+
+  @Test
+  @DisplayName("PowerQueryReference factory should create power query reference")
+  void shouldCreatePowerQueryReference() {
+    OdbcDsn odbcDsn =
+        OdbcDsn.of(
+            "testDSN",
+            OdbcEngine.SQLSERVER,
+            List.of(Attribute.of("host", "localhost"), Attribute.of("port", "1433")));
+    PowerQueryReference powerQueryReference =
+        PowerQueryReference.of(
+            "let source = Odbc.Query(\"dsn=testDSN\", \"SELECT * FROM table\") in source",
+            List.of(odbcDsn));
+    assertNotNull(powerQueryReference);
+    assertEquals(
+        "let source = Odbc.Query(\"dsn=testDSN\", \"SELECT * FROM table\") in source",
+        powerQueryReference.getPowerQuery());
+    assertEquals(List.of(odbcDsn), powerQueryReference.getDsns());
+  }
+
+  @Test
+  @DisplayName("PowerQueryReference should be equal to another with same properties")
+  void shouldBeEqualToAnotherWithSameProperties() {
+    OdbcDsn odbcDsn =
+        OdbcDsn.of(
+            "testDSN",
+            OdbcEngine.SQLSERVER,
+            List.of(Attribute.of("host", "localhost"), Attribute.of("port", "1433")));
+    PowerQueryReference powerQueryReference1 =
+        PowerQueryReference.of(
+            "let source = Odbc.Query(\"dsn=testDSN\", \"SELECT * FROM table\") in source",
+            List.of(odbcDsn));
+    PowerQueryReference powerQueryReference2 =
+        PowerQueryReference.of(
+            "let source = Odbc.Query(\"dsn=testDSN\", \"SELECT * FROM table\") in source",
+            List.of(odbcDsn));
+    assertEquals(powerQueryReference1, powerQueryReference2);
+    assertEquals(powerQueryReference1.hashCode(), powerQueryReference2.hashCode());
+  }
+
+  @Test
+  @DisplayName("PowerQueryReference should not be equal to another with different properties")
+  void shouldNotBeEqualToAnotherWithDifferentProperties() {
+    OdbcDsn odbcDsn1 =
+        OdbcDsn.of(
+            "testDSN1",
+            OdbcEngine.SQLSERVER,
+            List.of(Attribute.of("host", "localhost"), Attribute.of("port", "1433")));
+    OdbcDsn odbcDsn2 =
+        OdbcDsn.of(
+            "testDSN2",
+            OdbcEngine.ORACLE,
+            List.of(Attribute.of("host", "remotehost"), Attribute.of("port", "1521")));
+    PowerQueryReference powerQueryReference1 =
+        PowerQueryReference.of(
+            "let source = Odbc.Query(\"dsn=testDSN1\", \"SELECT * FROM table1\") in source",
+            List.of(odbcDsn1));
+    PowerQueryReference powerQueryReference2 =
+        PowerQueryReference.of(
+            "let source = Odbc.Query(\"dsn=testDSN2\", \"SELECT * FROM table2\") in source",
+            List.of(odbcDsn2));
+    assertNotEquals(powerQueryReference1, powerQueryReference2);
+  }
+
+  @Test
+  @DisplayName("PowerQueryReference factory should fail with null Power Query")
+  void shouldFailWithNullPowerQuery() {
+    OdbcDsn odbcDsn =
+        OdbcDsn.of(
+            "testDSN",
+            OdbcEngine.SQLSERVER,
+            List.of(Attribute.of("host", "localhost"), Attribute.of("port", "1433")));
+    assertThrows(NullPointerException.class, () -> PowerQueryReference.of(null, List.of(odbcDsn)));
+  }
+
+  @Test
+  @DisplayName("PowerQueryReference.of should create a power query reference without DSNs")
+  void shouldCreatePowerQueryReferenceWithoutDsns() {
+    PowerQueryReference powerQueryReference =
+        PowerQueryReference.of(
+            "let source = Excel.Workbook(File.Contents(\"C:\\data.xlsx\")) in source");
+    assertNotNull(powerQueryReference);
+    assertEquals(
+        "let source = Excel.Workbook(File.Contents(\"C:\\data.xlsx\")) in source",
+        powerQueryReference.getPowerQuery());
+    assertEquals(List.of(), powerQueryReference.getDsns());
+  }
+
+  @Test
+  @DisplayName("PowerQueryReference builder should handle valid inputs")
+  void shouldCreatePowerQueryReferenceWithBuilder() {
+    OdbcDsn odbcDsn =
+        OdbcDsn.of(
+            "testDSN",
+            OdbcEngine.SQLSERVER,
+            List.of(Attribute.of("host", "localhost"), Attribute.of("port", "1433")));
+    PowerQueryReference powerQueryReference =
+        PowerQueryReference.builder()
+            .powerQuery(
+                "let source = Odbc.Query(\"dsn=testDSN\", \"SELECT * FROM table\") in source")
+            .dsns(List.of(odbcDsn))
+            .build();
+    assertNotNull(powerQueryReference);
+    assertEquals(
+        "let source = Odbc.Query(\"dsn=testDSN\", \"SELECT * FROM table\") in source",
+        powerQueryReference.getPowerQuery());
+    assertEquals(List.of(odbcDsn), powerQueryReference.getDsns());
+  }
+
+  @Test
+  @DisplayName("PowerQueryReference builder should handle null DSNs")
+  void shouldCreatePowerQueryReferenceWithBuilderNullDsns() {
+    PowerQueryReference powerQueryReference =
+        PowerQueryReference.builder()
+            .powerQuery("let source = Excel.Workbook(File.Contents(\"C:\\data.xlsx\")) in source")
+            .dsns(null)
+            .build();
+    assertNotNull(powerQueryReference);
+    assertEquals(
+        "let source = Excel.Workbook(File.Contents(\"C:\\data.xlsx\")) in source",
+        powerQueryReference.getPowerQuery());
+    assertEquals(List.of(), powerQueryReference.getDsns());
+  }
+}

--- a/src/test/java/zeenea/connector/dataset/DatasetTest.java
+++ b/src/test/java/zeenea/connector/dataset/DatasetTest.java
@@ -6,6 +6,10 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import zeenea.connector.common.*;
+import zeenea.connector.common.powerquery.Attribute;
+import zeenea.connector.common.powerquery.OdbcDsn;
+import zeenea.connector.common.powerquery.OdbcEngine;
+import zeenea.connector.common.powerquery.PowerQueryReference;
 import zeenea.connector.field.Field;
 
 class DatasetTest {
@@ -54,6 +58,16 @@ class DatasetTest {
                 "SELECT * FROM table",
                 SqlDialect.MYSQL,
                 DataSourceIdentifier.of(List.of(IdentificationProperty.of("host", "localhost")))));
+    List<PowerQueryReference> sourcePowerQueries =
+        List.of(
+            PowerQueryReference.of(
+                "let source = Odbc.Query(\"dsn=testDSN\", \"SELECT * FROM table\") in source",
+                List.of(
+                    OdbcDsn.of(
+                        "testDSN",
+                        OdbcEngine.SQLSERVER,
+                        List.of(
+                            Attribute.of("host", "localhost"), Attribute.of("port", "1433"))))));
     ItemIdentifier itemIdentifier =
         ItemIdentifier.of(List.of(IdentificationProperty.of("key", "dataset1")));
     DataSourceIdentifier dataSourceIdentifier =
@@ -70,6 +84,7 @@ class DatasetTest {
             .foreignKeys(foreignKeys)
             .sourceDatasets(sourceDatasets)
             .sourceQueries(sourceQueries)
+            .sourcePowerQueries(sourcePowerQueries)
             .nestedImport(true)
             .build();
     assertNotNull(dataset);
@@ -79,6 +94,7 @@ class DatasetTest {
     assertEquals(foreignKeys, dataset.getForeignKeys());
     assertEquals(sourceDatasets, dataset.getSourceDatasets());
     assertEquals(sourceQueries, dataset.getSourceQueries());
+    assertEquals(sourcePowerQueries, dataset.getSourcePowerQueries());
     assertTrue(dataset.isNestedImport());
   }
 
@@ -192,6 +208,16 @@ class DatasetTest {
                         IdentificationProperty.of("host", "localhost"),
                         IdentificationProperty.of("port", "1111")))));
     List<QueryReference> sourceQueries = List.of(QueryReference.of("SELECT 1", SqlDialect.MYSQL));
+    List<PowerQueryReference> sourcePowerQueries =
+        List.of(
+            PowerQueryReference.of(
+                "let source = Odbc.Query(\"dsn=testDSN\", \"SELECT * FROM table\") in source",
+                List.of(
+                    OdbcDsn.of(
+                        "testDSN",
+                        OdbcEngine.SQLSERVER,
+                        List.of(
+                            Attribute.of("host", "localhost"), Attribute.of("port", "1433"))))));
     ItemIdentifier itemIdentifier =
         ItemIdentifier.of(List.of(IdentificationProperty.of("key", "dataset1")));
     DataSourceIdentifier dataSourceIdentifier =
@@ -207,6 +233,7 @@ class DatasetTest {
             .foreignKeys(foreignKeys)
             .sourceDatasets(sourceDatasets)
             .sourceQueries(sourceQueries)
+            .sourcePowerQueries(sourcePowerQueries)
             .nestedImport(true)
             .build();
     Dataset dataset2 =
@@ -220,6 +247,7 @@ class DatasetTest {
             .foreignKeys(foreignKeys)
             .sourceDatasets(sourceDatasets)
             .sourceQueries(sourceQueries)
+            .sourcePowerQueries(sourcePowerQueries)
             .nestedImport(true)
             .build();
     assertEquals(dataset1, dataset2);
@@ -277,6 +305,17 @@ class DatasetTest {
                                 IdentificationProperty.of("host", "localhost"),
                                 IdentificationProperty.of("port", "1111"))))))
             .sourceQueries(List.of(QueryReference.of("SELECT * FROM t1", SqlDialect.DB2)))
+            .sourcePowerQueries(
+                List.of(
+                    PowerQueryReference.of(
+                        "let source = Odbc.Query(\"dsn=testDSN\", \"SELECT * FROM table\") in source",
+                        List.of(
+                            OdbcDsn.of(
+                                "testDSN",
+                                OdbcEngine.SQLSERVER,
+                                List.of(
+                                    Attribute.of("host", "localhost"),
+                                    Attribute.of("port", "1433")))))))
             .build();
     Dataset dataset2 =
         Dataset.builder()
@@ -291,6 +330,7 @@ class DatasetTest {
             .foreignKeys(List.of())
             .sourceDatasets(List.of())
             .sourceQueries(List.of())
+            .sourcePowerQueries(List.of())
             .build();
     assertNotEquals(dataset1, dataset2);
   }
@@ -324,6 +364,16 @@ class DatasetTest {
                         IdentificationProperty.of("host", "localhost"),
                         IdentificationProperty.of("port", "1111")))));
     List<QueryReference> sourceQueries = List.of(QueryReference.of("SELECT 1", SqlDialect.MYSQL));
+    List<PowerQueryReference> sourcePowerQueries =
+        List.of(
+            PowerQueryReference.of(
+                "let source = Odbc.Query(\"dsn=testDSN\", \"SELECT * FROM table\") in source",
+                List.of(
+                    OdbcDsn.of(
+                        "testDSN",
+                        OdbcEngine.SQLSERVER,
+                        List.of(
+                            Attribute.of("host", "localhost"), Attribute.of("port", "1433"))))));
     assertThrows(
         NullPointerException.class,
         () ->
@@ -336,6 +386,7 @@ class DatasetTest {
                 .foreignKeys(foreignKeys)
                 .sourceDatasets(sourceDatasets)
                 .sourceQueries(sourceQueries)
+                .sourcePowerQueries(sourcePowerQueries)
                 .build());
   }
 }

--- a/src/test/java/zeenea/connector/dataset/DatasetTest.java
+++ b/src/test/java/zeenea/connector/dataset/DatasetTest.java
@@ -58,16 +58,7 @@ class DatasetTest {
                 "SELECT * FROM table",
                 SqlDialect.MYSQL,
                 DataSourceIdentifier.of(List.of(IdentificationProperty.of("host", "localhost")))));
-    List<PowerQueryReference> sourcePowerQueries =
-        List.of(
-            PowerQueryReference.of(
-                "let source = Odbc.Query(\"dsn=testDSN\", \"SELECT * FROM table\") in source",
-                List.of(
-                    OdbcDsn.of(
-                        "testDSN",
-                        OdbcEngine.SQLSERVER,
-                        List.of(
-                            Attribute.of("host", "localhost"), Attribute.of("port", "1433"))))));
+    List<PowerQueryReference> sourcePowerQueries = List.of(createPowerQueryReference());
     ItemIdentifier itemIdentifier =
         ItemIdentifier.of(List.of(IdentificationProperty.of("key", "dataset1")));
     DataSourceIdentifier dataSourceIdentifier =
@@ -208,16 +199,7 @@ class DatasetTest {
                         IdentificationProperty.of("host", "localhost"),
                         IdentificationProperty.of("port", "1111")))));
     List<QueryReference> sourceQueries = List.of(QueryReference.of("SELECT 1", SqlDialect.MYSQL));
-    List<PowerQueryReference> sourcePowerQueries =
-        List.of(
-            PowerQueryReference.of(
-                "let source = Odbc.Query(\"dsn=testDSN\", \"SELECT * FROM table\") in source",
-                List.of(
-                    OdbcDsn.of(
-                        "testDSN",
-                        OdbcEngine.SQLSERVER,
-                        List.of(
-                            Attribute.of("host", "localhost"), Attribute.of("port", "1433"))))));
+    List<PowerQueryReference> sourcePowerQueries = List.of(createPowerQueryReference());
     ItemIdentifier itemIdentifier =
         ItemIdentifier.of(List.of(IdentificationProperty.of("key", "dataset1")));
     DataSourceIdentifier dataSourceIdentifier =
@@ -305,17 +287,7 @@ class DatasetTest {
                                 IdentificationProperty.of("host", "localhost"),
                                 IdentificationProperty.of("port", "1111"))))))
             .sourceQueries(List.of(QueryReference.of("SELECT * FROM t1", SqlDialect.DB2)))
-            .sourcePowerQueries(
-                List.of(
-                    PowerQueryReference.of(
-                        "let source = Odbc.Query(\"dsn=testDSN\", \"SELECT * FROM table\") in source",
-                        List.of(
-                            OdbcDsn.of(
-                                "testDSN",
-                                OdbcEngine.SQLSERVER,
-                                List.of(
-                                    Attribute.of("host", "localhost"),
-                                    Attribute.of("port", "1433")))))))
+            .sourcePowerQueries(List.of(createPowerQueryReference()))
             .build();
     Dataset dataset2 =
         Dataset.builder()
@@ -364,16 +336,7 @@ class DatasetTest {
                         IdentificationProperty.of("host", "localhost"),
                         IdentificationProperty.of("port", "1111")))));
     List<QueryReference> sourceQueries = List.of(QueryReference.of("SELECT 1", SqlDialect.MYSQL));
-    List<PowerQueryReference> sourcePowerQueries =
-        List.of(
-            PowerQueryReference.of(
-                "let source = Odbc.Query(\"dsn=testDSN\", \"SELECT * FROM table\") in source",
-                List.of(
-                    OdbcDsn.of(
-                        "testDSN",
-                        OdbcEngine.SQLSERVER,
-                        List.of(
-                            Attribute.of("host", "localhost"), Attribute.of("port", "1433"))))));
+    List<PowerQueryReference> sourcePowerQueries = List.of(createPowerQueryReference());
     assertThrows(
         NullPointerException.class,
         () ->
@@ -388,5 +351,15 @@ class DatasetTest {
                 .sourceQueries(sourceQueries)
                 .sourcePowerQueries(sourcePowerQueries)
                 .build());
+  }
+
+  private static PowerQueryReference createPowerQueryReference() {
+    return PowerQueryReference.of(
+        "let source = Odbc.Query(\"dsn=testDSN\", \"SELECT * FROM table\") in source",
+        List.of(
+            OdbcDsn.of(
+                "testDSN",
+                OdbcEngine.SQLSERVER,
+                List.of(Attribute.of("host", "localhost"), Attribute.of("port", "1433")))));
   }
 }


### PR DESCRIPTION
JIRA issue: https://actian.atlassian.net/browse/ZEE-9665

##### PR summary:

- New classes to associate Power Queries with datasets, to replace passing the Power Query to the platform via a property.
- This will be utilized by Fabric/PowerBI connector to pass the Power Query + DSN details that come from the connector's configuration.

##### Checklist for Developer:

- [ x ] Summary part has been documented
- [ x ] Reviewers have been requested
- [ ] Reviews & comments have been taken into consideration
- [ ] Commits have been reworded and history cleaned

##### Checklist for Reviewer

- [ ] Code has been reviewed, commented and changes have been requested
- [ ] Reviews & comments have been taken into consideration


 
