### PR TITLE
[ZEE-10296] Allow an empty data sample response to be returned

### DIFF
--- a/src/main/java/zeenea/connector/datasampling/DataSampleResponse.java
+++ b/src/main/java/zeenea/connector/datasampling/DataSampleResponse.java
@@ -1,16 +1,33 @@
 package zeenea.connector.datasampling;
 
+import java.util.Optional;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 /** Response of a Data Sample */
 public class DataSampleResponse {
 
   /** The sampling result */
-  private final DataSample sample;
+  @Nullable private final DataSample sample;
 
-  public DataSampleResponse(DataSample sample) {
+  /**
+   * Returns an empty DataSampleResponse with no sample. This can be used when sampling fails or is
+   * not applicable, allowing the caller to handle the absence of a sample gracefully.
+   */
+  public DataSampleResponse() {
+    this.sample = null;
+  }
+
+  /**
+   * Returns a DataSampleResponse with the provided sample.
+   *
+   * @param sample that can not be null
+   */
+  public DataSampleResponse(@NotNull DataSample sample) {
     this.sample = sample;
   }
 
-  public DataSample getSample() {
-    return sample;
+  public Optional<DataSample> getSample() {
+    return Optional.ofNullable(sample);
   }
 }


### PR DESCRIPTION
JIRA issue: https://actian.atlassian.net/browse/ZEE-10296

##### PR summary:

Adds a constructor in DataSampleResponse for an empty response

##### Checklist for Developer:

- [ ] Summary part has been documented
- [ ] Reviewers have been requested
- [ ] Reviews & comments have been taken into consideration
- [ ] Commits have been reworded and history cleaned

##### Checklist for Reviewer

- [ ] Code has been reviewed, commented and changes have been requested
- [ ] Reviews & comments have been taken into consideration


 
